### PR TITLE
Issue-76 - add scrolling on up and down key events

### DIFF
--- a/src/auto-complete.component.ts
+++ b/src/auto-complete.component.ts
@@ -291,7 +291,6 @@ export class NguiAutoCompleteComponent implements OnInit {
     const scrollTop = ul.scrollTop;
     const viewport = scrollTop + ul.offsetHeight;
     const scrollOffset = liHeight * index;
-    //console.log('scrollTop', scrollTop, ' viewport', viewport, ' elOffset', scrollOffset);
     if (scrollOffset < scrollTop || (scrollOffset + liHeight) > viewport) {
       ul.scrollTop = scrollOffset;
     }

--- a/src/auto-complete.component.ts
+++ b/src/auto-complete.component.ts
@@ -19,8 +19,7 @@ import { NguiAutoComplete } from "./auto-complete";
 @Component({
   selector: "ngui-auto-complete",
   template: `
-  <div class="ngui-auto-complete">
-
+  <div #autoCompleteContainer class="ngui-auto-complete">
     <!-- keyword input -->
     <input *ngIf="showInputTag"
            #autoCompleteInput class="keyword"
@@ -126,6 +125,7 @@ export class NguiAutoCompleteComponent implements OnInit {
 
   @Output() valueSelected = new EventEmitter();
   @ViewChild('autoCompleteInput') autoCompleteInput: ElementRef;
+  @ViewChild('autoCompleteContainer') autoCompleteContainer: ElementRef;
 
   el: HTMLElement;           // this component  element `<ngui-auto-complete>`
 
@@ -258,11 +258,13 @@ export class NguiAutoCompleteComponent implements OnInit {
 
       case 38: // UP, select the previous li el
         this.itemIndex = (totalNumItem + this.itemIndex - 1) % totalNumItem;
+        this.scrollToView(this.itemIndex);
         break;
 
       case 40: // DOWN, select the next li el or the first one
         this.dropdownVisible = true;
         this.itemIndex = (totalNumItem + this.itemIndex + 1) % totalNumItem;
+        this.scrollToView(this.itemIndex);
         break;
 
       case 13: // ENTER, choose it!!
@@ -279,6 +281,21 @@ export class NguiAutoCompleteComponent implements OnInit {
         break;
     }
   };
+
+
+  scrollToView(index) {
+    const container = this.autoCompleteContainer.nativeElement;
+    const ul = container.querySelector('ul');
+    const li = ul.querySelector('li');  //just sample the first li to get height
+    const liHeight = li.offsetHeight;
+    const scrollTop = ul.scrollTop;
+    const viewport = scrollTop + ul.offsetHeight;
+    const scrollOffset = liHeight * index;
+    //console.log('scrollTop', scrollTop, ' viewport', viewport, ' elOffset', scrollOffset);
+    if (scrollOffset < scrollTop || (scrollOffset + liHeight) > viewport) {
+      ul.scrollTop = scrollOffset;
+    }
+  }
 
   get emptyList(): boolean {
     return !(


### PR DESCRIPTION
Hi,

This addresses issue 76: #76

We intend to use your component on a government site in Queensland Australia, but will need to be able to scroll using the arrow keys as described in issue 76.

This PR provides this functionality.

I am not sure if the approach I took using querySelector is the best approach, but I could not get it working using the ElementRef to "el" in the existing code. This was always coming back as an empty object.

So I just added a new ViewChild on the container div and then querySelector to get the child ul and li elements from there.

You can test it out by adding something like this to the css of the host website:

ngui-auto-complete ul {
height: 100px;
overflow-y:auto;
}

as you move through the elements with the down arrow the scrollTop is adjusted to keep the current element visible.