### PR TITLE
Adding of z-index input directive

### DIFF
--- a/app/directive-test.component.ts
+++ b/app/directive-test.component.ts
@@ -31,7 +31,8 @@ let templateStr: string = `
         blank-option-text="Select One"
         [(ngModel)]="model2"
         [source]="arrayOfKeyValues" 
-        placeholder="enter text"/> 
+        placeholder="enter text"
+        z-index="4"/> 
       <a href="javascript:void(0)" (click)="model2={id:'change', value: 'it'}">Change It</a>
       <br/>selected model2: {{model2 | json}}<br/><br/>
     </ngui-utils-2>

--- a/src/auto-complete.directive.ts
+++ b/src/auto-complete.directive.ts
@@ -46,6 +46,7 @@ export class NguiAutoCompleteDirective implements OnInit {
   //if [formControl] is used on the anchor where our directive is sitting
   //a form is not necessary to use a formControl we should also support this
   @Input('formControl') extFormControl: FormControl;
+  @Input("z-index") zIndex: string = "1";
 
   @Output() ngModelChange = new EventEmitter();
   @Output() valueChanged = new EventEmitter();
@@ -198,7 +199,7 @@ export class NguiAutoCompleteDirective implements OnInit {
 
       this.acDropdownEl.style.width = thisInputElBCR.width + "px";
       this.acDropdownEl.style.position = "absolute";
-      this.acDropdownEl.style.zIndex = "1";
+      this.acDropdownEl.style.zIndex = this.zIndex;
       this.acDropdownEl.style.left = "0";
       this.acDropdownEl.style.display = "inline-block";
 


### PR DESCRIPTION
I had issues with BS4 class `input-group`, the z-index was higher than auto-complete z-index.
I add the possiblity to set the z-index.