### PR TITLE
Issue 216 - Incorrect view initializing using ngModel

### DIFF
--- a/src/auto-complete.directive.ts
+++ b/src/auto-complete.directive.ts
@@ -11,7 +11,8 @@ import {
   SimpleChanges,
   SkipSelf,
   Host,
-  Optional
+  Optional,
+  OnChanges
 } from "@angular/core";
 import { NguiAutoCompleteComponent } from "./auto-complete.component";
 import { ControlContainer, AbstractControl, FormGroup, FormControl, FormGroupName } from "@angular/forms";
@@ -22,7 +23,7 @@ import { ControlContainer, AbstractControl, FormGroup, FormControl, FormGroupNam
 @Directive({
   selector: "[auto-complete], [ngui-auto-complete]"
 })
-export class NguiAutoCompleteDirective implements OnInit {
+export class NguiAutoCompleteDirective implements OnInit, OnChanges {
 
   @Input("auto-complete-placeholder") autoCompletePlaceholder: string;
   @Input("source") source: any;
@@ -62,7 +63,7 @@ export class NguiAutoCompleteDirective implements OnInit {
   private scheduledBlurHandler: any;
 
 
-    constructor(private resolver: ComponentFactoryResolver,
+  constructor(private resolver: ComponentFactoryResolver,
               private renderer: Renderer,
               public  viewContainerRef: ViewContainerRef,
               @Optional() @Host() @SkipSelf() private parentForm: ControlContainer) {
@@ -131,6 +132,7 @@ export class NguiAutoCompleteDirective implements OnInit {
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['ngModel']) {
       this.ngModel = this.setToStringFunction(changes['ngModel'].currentValue);
+      this.renderValue(this.ngModel);
     }
   }
 
@@ -249,9 +251,7 @@ export class NguiAutoCompleteDirective implements OnInit {
       } else {
         displayVal = item.value;
       }
-      item.toString = function () {
-        return displayVal;
-      }
+      item.toString = () => displayVal;
     }
     return item;
   }
@@ -261,7 +261,7 @@ export class NguiAutoCompleteDirective implements OnInit {
     if (item && typeof item === "object") {
       item = this.setToStringFunction(item);
     }
-    this.inputEl && (this.inputEl.value = '' + item);
+    this.renderValue(item);
 
     // make return value
     let val = item;
@@ -295,4 +295,7 @@ export class NguiAutoCompleteDirective implements OnInit {
     }
   };
 
+  private renderValue(item: any) {
+    this.inputEl && (this.inputEl.value = '' + item);
+  }
 }


### PR DESCRIPTION
Solution for https://github.com/ng2-ui/auto-complete/issues/216
Reason for an issue was situation when ```ngModel``` value renders before we patching ```toString```.
But, as for me, it's not  a good practice, to mutate object, especially at override standart methods. I propose at least return a copy of object from ```setToStringFunction```. Am I right?