### PR TITLE
Automatically selecting first item is now optional

### DIFF
--- a/src/auto-complete.component.ts
+++ b/src/auto-complete.component.ts
@@ -124,6 +124,7 @@ export class NguiAutoCompleteComponent implements OnInit {
   @Input("show-dropdown-on-init") showDropdownOnInit: boolean = false;
   @Input("tab-to-select") tabToSelect: boolean = true;
   @Input("match-formatted") matchFormatted: boolean = false;
+  @Input("auto-complete-first-item") autoCompleteFirstItem: boolean = false;
 
   @Output() valueSelected = new EventEmitter();
   @ViewChild('autoCompleteInput') autoCompleteInput: ElementRef;
@@ -160,6 +161,9 @@ export class NguiAutoCompleteComponent implements OnInit {
     this.autoComplete.source = this.source;
     this.autoComplete.pathToData = this.pathToData;
     this.autoComplete.listFormatter = this.listFormatter;
+    if (this.autoCompleteFirstItem) {
+      this.itemIndex = 0;
+    }
     setTimeout(() => {
       if (this.autoCompleteInput) {
         this.autoCompleteInput.nativeElement.focus()

--- a/src/auto-complete.directive.ts
+++ b/src/auto-complete.directive.ts
@@ -41,6 +41,7 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges {
   @Input("value-formatter") valueFormatter: any;
   @Input("tab-to-select") tabToSelect: boolean = true;
   @Input("match-formatted") matchFormatted: boolean = false;
+  @Input("auto-complete-first-item") autoCompleteFirstItem: boolean = false;
 
   @Input() ngModel: String;
   @Input('formControlName') formControlName: string;
@@ -167,6 +168,7 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges {
     component.noMatchFoundText = this.noMatchFoundText;
     component.tabToSelect = this.tabToSelect;
     component.matchFormatted = this.matchFormatted;
+    component.autoCompleteFirstItem = this.autoCompleteFirstItem;
 
     component.valueSelected.subscribe(this.selectNewValue);
 


### PR DESCRIPTION
I can understand that in some cases, the expected behaviour is to *not* select first item. But it isn't always the case. The PR #240 remove completely the possibility to automatically select first item. Unfortunately, I require this feature (even if it's a bug for the rest of the world).

This PR adds an Input named `auto-complete-first-item`, that when set to true, will automatically select first element of list (as before). If the input is not specified or set to false, then the user will be force to select manually his desired value.