### PR TITLE
Add attribute autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ please send me email to `allenhwkim AT gmail.com` with your github id.
   * **`auto-select-first-item`**, boolean, if `true`, the first item of the list is automatically selected, if `false`, user must select manually an item. Default is `false`
   * **`open-on-focus`**, boolean, if `false` drop down won't open on a focus event, . Default is `true`
   * **`re-focus-after-select property`**, boolean, if `false` an auto focus behavior after select (example: custom value on blur event or issue #276) is disabled . Default is `true`
-  
+  * **`autocomplete`**, boolean, default `false`, if `true` remove the attribute `autocomplete="off"` of the input. 
 ## For Developers
 
 ### To start

--- a/app/directive-test.component.ts
+++ b/app/directive-test.component.ts
@@ -117,16 +117,16 @@ let templateStr: string = `
     
   <fieldset><legend><h2>With Material Design</h2></legend>
     <ngui-utils-6>
-      <md-input-container>
-        <span mdPrefix>$&nbsp;</span>
-        <input mdInput ngui-auto-complete style="border: 1px solid #ccc"
+      <mat-input-container>
+        <span matPrefix>$&nbsp;</span>
+        <input matInput ngui-auto-complete style="border: 1px solid #ccc"
           id="model6"
           [(ngModel)]="myModel"
           [source]="arrayOfNumbers"
           [list-formatter]="rightAligned"
           placeholder="amount" align="end"/>
-          <span mdSuffix>.00</span>
-      </md-input-container>
+          <span matSuffix>.00</span>
+      </mat-input-container>
     </ngui-utils-6>
     <pre>{{templateStr | htmlCode:'ngui-utils-6'}}</pre>
     <pre>arrayOfNumbers: {{json(arrayOfNumbers)}}</pre>

--- a/app/main.ts
+++ b/app/main.ts
@@ -10,7 +10,7 @@ import {BrowserModule} from '@angular/platform-browser';
 import {FormsModule} from '@angular/forms';
 import {HttpModule} from '@angular/http';
 import {NguiUtilsModule} from '@ngui/utils';
-import {MdInputModule} from '@angular/material';
+import {MatInputModule} from '@angular/material';
 import {HashLocationStrategy, LocationStrategy} from "@angular/common";
 
 import {AppComponent} from './app.component';
@@ -28,7 +28,7 @@ import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
         FormsModule,
         HttpModule,
         NguiUtilsModule,
-        MdInputModule,
+        MatInputModule,
         NguiAutoCompleteModule
     ],
     declarations: [AppComponent, APP_ROUTER_COMPONENTS],
@@ -37,8 +37,7 @@ import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
     ],
     bootstrap: [AppComponent]
 })
-export class AppModule {
-}
+export class AppModule { }
 
 // compile and launch the module
 platformBrowserDynamic().bootstrapModule(AppModule);

--- a/src/auto-complete.component.ts
+++ b/src/auto-complete.component.ts
@@ -14,6 +14,7 @@ import {NguiAutoComplete} from "./auto-complete";
     <!-- keyword input -->
     <input *ngIf="showInputTag"
            #autoCompleteInput class="keyword"
+           [attr.autocomplete]="autocomplete ? 'null' : 'off'"
            placeholder="{{placeholder}}"
            (focus)="showDropdownList($event)"
            (blur)="blurHandler($event)"
@@ -100,6 +101,7 @@ export class NguiAutoCompleteComponent implements OnInit {
   /**
    * public input properties
    */
+  @Input("autocomplete") autocomplete = false;
   @Input("list-formatter") listFormatter: (arg: any) => string;
   @Input("source") source: any;
   @Input("path-to-data") pathToData: string;

--- a/src/auto-complete.directive.ts
+++ b/src/auto-complete.directive.ts
@@ -24,6 +24,7 @@ import {AbstractControl, ControlContainer, FormControl, FormGroup, FormGroupName
 })
 export class NguiAutoCompleteDirective implements OnInit, OnChanges {
 
+  @Input("autocomplete") autocomplete = 'off';
   @Input("auto-complete-placeholder") autoCompletePlaceholder: string;
   @Input("source") source: any;
   @Input("path-to-data") pathToData: string;
@@ -123,9 +124,11 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges {
     this.inputEl = this.el.tagName === "INPUT" ?
         <HTMLInputElement>this.el : <HTMLInputElement>this.el.querySelector("input");
 
-      if (this.openOnFocus) {
-          this.inputEl.addEventListener('focus', e => this.showAutoCompleteDropdown(e));
-      }
+    if (this.openOnFocus) {
+        this.inputEl.addEventListener('focus', e => this.showAutoCompleteDropdown(e));
+    }
+
+    console.log(this.autocomplete);
     this.inputEl.addEventListener('blur', (e) => {
         this.scheduledBlurHandler = () => {
           return this.blurHandler(e);

--- a/src/auto-complete.directive.ts
+++ b/src/auto-complete.directive.ts
@@ -24,7 +24,7 @@ import {AbstractControl, ControlContainer, FormControl, FormGroup, FormGroupName
 })
 export class NguiAutoCompleteDirective implements OnInit, OnChanges {
 
-  @Input("autocomplete") autocomplete = 'off';
+  @Input("autocomplete") autocomplete = false;
   @Input("auto-complete-placeholder") autoCompletePlaceholder: string;
   @Input("source") source: any;
   @Input("path-to-data") pathToData: string;
@@ -128,7 +128,9 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges {
         this.inputEl.addEventListener('focus', e => this.showAutoCompleteDropdown(e));
     }
 
-    console.log(this.autocomplete);
+    if (!this.autocomplete) {
+      this.inputEl.setAttribute('autocomplete', 'off');
+    }
     this.inputEl.addEventListener('blur', (e) => {
         this.scheduledBlurHandler = () => {
           return this.blurHandler(e);


### PR DESCRIPTION
Hi, 
I added the attribute autocomplete which prevent browser to display a autofill list (and hide the ng-ui list autocomplete) as chrome ignore the form tag autocomplete attribute.

I also fixed the name of module and directives of Material Design.
Exemple: MdInputModule -> MatInputModule