### PR TITLE
add trackBy to ngFor to improve performance - notably in IE

### DIFF
--- a/src/auto-complete.component.ts
+++ b/src/auto-complete.component.ts
@@ -33,7 +33,7 @@ import {NguiAutoComplete} from "./auto-complete";
           (mousedown)="selectOne('')"
           class="blank-item">{{blankOptionText}}</li>
       <li class="item"
-          *ngFor="let item of filteredList; let i=index"
+          *ngFor="let item of filteredList; let i=index; trackBy: trackByIndex"
           (mousedown)="selectOne(item)"
           [ngClass]="{selected: i === itemIndex}"
           [innerHtml]="autoComplete.getFormattedListItem(item)">
@@ -319,6 +319,10 @@ export class NguiAutoCompleteComponent implements OnInit {
     if (scrollOffset < scrollTop || (scrollOffset + liHeight) > viewport) {
       ul.scrollTop = scrollOffset;
     }
+  }
+  
+  trackByIndex(index, item) {
+    return index;
   }
 
   get emptyList(): boolean {


### PR DESCRIPTION
Minor adjustment to add trackBy for elements in ngFor, because in IE11 screens with a lot of auto-complete controls become so slow it's unusable.