### PR TITLE
Implement an option to match user input ignoring accents 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### [1.2.1]
+- Added new property `ignore-accents`
 ### [1.2.0]
 - Upgraded to Angular 6
 ### [1.0.2] 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ You can look at different show cases for it here as [Component](https://rawgit.c
   * **`re-focus-after-select property`**, boolean, if `false` an auto focus behavior after select (example: custom value on blur event or issue #276) is disabled . Default is `true`
   * **`autocomplete`**, boolean, default `false`, if `true` remove the attribute `autocomplete="off"` of the input.
   * **`header-item-template`**, html markup to optionally create a non-selectable header row above the list of results. Default, null
-  * **`ignore-accents`**, boolean, default `false`, if `true` matches user input with source given ignoring accents or diacritics included in the [Unicode Combining Diacritical Marks block](https://www.wikiwand.com/en/Combining_Diacritical_Marks)
+  * **`ignore-accents`**, boolean, default `true`, if `false` user input must match exactly with source given, including accents or diacritics
 
 ## Below are plunks for different scenarios:
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ You can look at different show cases for it here as [Component](https://rawgit.c
   * **`re-focus-after-select property`**, boolean, if `false` an auto focus behavior after select (example: custom value on blur event or issue #276) is disabled . Default is `true`
   * **`autocomplete`**, boolean, default `false`, if `true` remove the attribute `autocomplete="off"` of the input.
   * **`header-item-template`**, html markup to optionally create a non-selectable header row above the list of results. Default, null
+  * **`ignore-accents`**, boolean, default `false`, if `true` matches user input with source given ignoring accents or diacritics included in the [Unicode Combining Diacritical Marks block](https://www.wikiwand.com/en/Combining_Diacritical_Marks)
 
 ## Below are plunks for different scenarios:
 

--- a/app/directive-test.component.ts
+++ b/app/directive-test.component.ts
@@ -177,6 +177,25 @@ const templateStr: string = `
     <pre>{{templateStr | htmlCode:'ngui-utils-9'}}</pre>
     <pre> arrayOfCities: {{json(arrayOfCities)}}</pre>
   </fieldset>
+
+   <fieldset><legend><h2>Ignore Accents Option</h2></legend>
+    <ngui-utils-10>
+      <div ngui-auto-complete
+        [ignore-accents] = "true"
+        [source]="arrayOfAccentedStrings"
+        [accept-user-input]="true"
+        [auto-select-first-item]="false"
+        [select-on-blur]="true"
+        (ngModelChange)="myCallback10($event)"
+        (customSelected)="customCallback($event)"
+        placeholder="enter text">
+        <input id="model10" [ngModel]="model10" autofocus />
+      </div>
+      <br/>selected model10: {{json(model10)}}<br/><br/>
+    </ngui-utils-10>
+    <pre>{{templateStr | htmlCode:'ngui-utils-10'}}</pre>
+    <pre> arrayOfStrings: {{json(arrayOfAccentedStrings)}}</pre>
+  </fieldset>
  `;
 
 @Component({
@@ -237,6 +256,7 @@ export class DirectiveTestComponent {
       </div>`;
     public arrayOfNumbers: number[] = [100, 200, 300, 400, 500];
     public arrayOfStrings: string[] = ['this', 'is', 'array', 'of', 'text', 'with', 'long', 'and long', 'and long', 'list'];
+    public arrayOfAccentedStrings: string[] = ['Cádiz', 'München'];
 
     public arrayOfKeyValues: any[] =
         [{id: 1, value: 'One'}, {id: 2, value: 'Two'}, {id: 3, value: 'Three'}, {
@@ -271,6 +291,7 @@ export class DirectiveTestComponent {
     public model7 = '';
     public model8 = '';
     public model9 = '';
+    public model10 = '';
 
     constructor(public http: HttpClient, public appSvc: AppSvc, private _sanitizer: DomSanitizer) {
     }
@@ -292,6 +313,11 @@ export class DirectiveTestComponent {
     public myCallback8(newVal8) {
         console.log('value is changed to ', newVal8);
         this.model8 = newVal8;
+    }
+
+    public myCallback10(newVal10) {
+        console.log('value is changed to ', newVal10);
+        this.model10 = newVal10;
     }
 
     public renderHero(data: any): SafeHtml {

--- a/app/directive-test.component.ts
+++ b/app/directive-test.component.ts
@@ -178,10 +178,10 @@ const templateStr: string = `
     <pre> arrayOfCities: {{json(arrayOfCities)}}</pre>
   </fieldset>
 
-   <fieldset><legend><h2>Ignore Accents Option</h2></legend>
+   <fieldset><legend><h2>Exact Match Including Accents</h2></legend>
     <ngui-utils-10>
       <div ngui-auto-complete
-        [ignore-accents] = "true"
+        [ignore-accents] = "false"
         [source]="arrayOfAccentedStrings"
         [accept-user-input]="true"
         [auto-select-first-item]="false"

--- a/src/auto-complete.component.ts
+++ b/src/auto-complete.component.ts
@@ -138,7 +138,7 @@ export class NguiAutoCompleteComponent implements OnInit {
     @Input('select-on-blur') public selectOnBlur: boolean = false;
     @Input('re-focus-after-select') public reFocusAfterSelect: boolean = true;
     @Input('header-item-template') public headerItemTemplate = null;
-    @Input('ignore-accents') public ignoreAccents: boolean = false;
+    @Input('ignore-accents') public ignoreAccents: boolean = true;
 
     @Output() public valueSelected = new EventEmitter();
     @Output() public customSelected = new EventEmitter();

--- a/src/auto-complete.component.ts
+++ b/src/auto-complete.component.ts
@@ -138,6 +138,7 @@ export class NguiAutoCompleteComponent implements OnInit {
     @Input('select-on-blur') public selectOnBlur: boolean = false;
     @Input('re-focus-after-select') public reFocusAfterSelect: boolean = true;
     @Input('header-item-template') public headerItemTemplate = null;
+    @Input('ignore-accents') public ignoreAccents: boolean = false;
 
     @Output() public valueSelected = new EventEmitter();
     @Output() public customSelected = new EventEmitter();
@@ -232,7 +233,7 @@ export class NguiAutoCompleteComponent implements OnInit {
 
         if (this.isSrcArr()) {    // local source
             this.isLoading = false;
-            this.filteredList = this.autoComplete.filter(this.source, keyword, this.matchFormatted);
+            this.filteredList = this.autoComplete.filter(this.source, keyword, this.matchFormatted, this.ignoreAccents);
             if (this.maxNumList) {
                 this.filteredList = this.filteredList.slice(0, this.maxNumList);
             }

--- a/src/auto-complete.directive.ts
+++ b/src/auto-complete.directive.ts
@@ -54,6 +54,7 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
     @Input('close-on-focusout') public closeOnFocusOut: boolean = true;
     @Input('re-focus-after-select') public reFocusAfterSelect: boolean = true;
     @Input('header-item-template') public headerItemTemplate = null;
+    @Input('ignore-accents') public ignoreAccents: boolean = false;
 
     @Input() public ngModel: string;
     @Input('formControlName') public formControlName: string;
@@ -199,6 +200,7 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
         component.matchFormatted = this.matchFormatted;
         component.autoSelectFirstItem = this.autoSelectFirstItem;
         component.headerItemTemplate = this.headerItemTemplate;
+        component.ignoreAccents = this.ignoreAccents;
 
         component.valueSelected.subscribe(this.selectNewValue);
         component.textEntered.subscribe(this.enterNewText);

--- a/src/auto-complete.directive.ts
+++ b/src/auto-complete.directive.ts
@@ -54,7 +54,7 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges, AfterViewIn
     @Input('close-on-focusout') public closeOnFocusOut: boolean = true;
     @Input('re-focus-after-select') public reFocusAfterSelect: boolean = true;
     @Input('header-item-template') public headerItemTemplate = null;
-    @Input('ignore-accents') public ignoreAccents: boolean = false;
+    @Input('ignore-accents') public ignoreAccents: boolean = true;
 
     @Input() public ngModel: string;
     @Input('formControlName') public formControlName: string;

--- a/src/auto-complete.ts
+++ b/src/auto-complete.ts
@@ -17,15 +17,24 @@ export class NguiAutoComplete {
         // ...
     }
 
-    public filter(list: any[], keyword: string, matchFormatted: boolean) {
-        return list.filter(
-            (el) => {
-                const objStr = matchFormatted ? this.getFormattedListItem(el).toLowerCase() : JSON.stringify(el).toLowerCase();
-                keyword = keyword.toLowerCase();
+    public filter(list: any[], keyword: string, matchFormatted: boolean, accentInsensitive: boolean) {
+        return accentInsensitive
+            ? list.filter(
+                (el) => {
+                    const objStr = matchFormatted ? this.getFormattedListItem(el).toLowerCase() : JSON.stringify(el).toLowerCase();
+                    keyword = keyword.toLowerCase();
 
-                return objStr.indexOf(keyword) !== -1;
-            }
-        );
+                    return objStr.normalize( 'NFD' ).replace( /[\u0300-\u036f]/g, '' )
+                        .indexOf(keyword.normalize( 'NFD' ).replace( /[\u0300-\u036f]/g, '' )) !== -1;
+                })
+            : list.filter(
+                (el) => {
+                    const objStr = matchFormatted ? this.getFormattedListItem(el).toLowerCase() : JSON.stringify(el).toLowerCase();
+                    keyword = keyword.toLowerCase();
+
+                    return objStr.indexOf(keyword) !== -1;
+                }
+            );
     }
 
     public getFormattedListItem(data: any) {


### PR DESCRIPTION
Currently, auto-complete doesn't match the given source when it contains a character with a diacritic mark if the user forgets to include said mark (ie. an input of 'a' won't match 'á'). But most users don't tend to type accents, as they require two keystrokes as opposed to one. This means a user which inputs 'Krakow' won't find the existing entry for 'Kraków', which forces the developer to choose between a non grammatically correct source or finding a more complex solution.

With the ignore-accents option set to true, the filter function cleans accents from both strings before comparing, which ensures that the users gets a correct match even if they didn't include the diacritic mark.

I have updated the readme to include a brief description of the new option, and added a working example to the demo app.