### PR TITLE
When using autoSelectFirstItem option, Enter does not work on the first item

### DIFF
--- a/src/auto-complete.component.ts
+++ b/src/auto-complete.component.ts
@@ -298,6 +298,10 @@ export class NguiAutoCompleteComponent implements OnInit {
     public inputElKeyHandler = (evt: any) => {
         const totalNumItem = this.filteredList.length;
 
+        if (!this.selectOnEnter && this.autoSelectFirstItem && (0 !== totalNumItem)){
+            this.selectOnEnter = true;
+        }
+
         switch (evt.keyCode) {
             case 27: // ESC, hide auto complete
                 this.selectOnEnter = false;


### PR DESCRIPTION
Hi.
selectOnEnter is not active, so selectOne function does not execute under event 13 of inputElKeyHandler function